### PR TITLE
feat: 스토리 조회 및 생성 시 neo4j 스토리 아이디 response 구현

### DIFF
--- a/neo_db/apps.py
+++ b/neo_db/apps.py
@@ -93,21 +93,24 @@ class NeoDbConfig(AppConfig):
         """
         session.run(query, parameters=fields)
 
-    # @staticmethod
-    # def get_story_id(session, image_url):
-    #     # 스토리 아이디 반환 쿼리
-    #     query = """
-    #             MATCH (s:Story)
-    #             WHERE s.image_url = $image_url
-    #             RETURN ID(s) AS story_id
-    #             """
-    #     result = session.run(query, image_url=image_url)
-    #     logger.error('result: ', result)
-    #     story_id = result.single()[0]
-    #     if story_id is None:
-    #         logger.error('story_id 내용물이 없음')
-    #     logger.error('story_id: ', story_id)
-    #     return story_id
+    @staticmethod
+    def get_story_id(session, image_url):
+        # 스토리 아이디 반환 쿼리
+        query = """
+                MATCH (s:Story)
+                WHERE s.image_url = $image_url
+                RETURN ID(s) AS story_id
+                """
+        result = session.run(query, image_url=image_url)
+        record = result.single()
+
+        if record is None:
+            logger.error('story_id 내용물이 없음')
+            return None
+
+        story_id = record['story_id']
+        logger.error(f'story_id: {story_id}')
+        return story_id
 
     @staticmethod
     def create_story(session, fields):
@@ -116,6 +119,8 @@ class NeoDbConfig(AppConfig):
         CREATE (s:Story {user_nickname: $user_nickname, content: $content, created_at: $created_at, updated_at: $updated_at, is_deleted: $is_deleted, image_url: $image_url})
         """
         session.run(create_story_query, parameters=fields)
+
+        # return result.single()['s'] # 생성된 내용 돌려줌
 
         # 스토리 간의 관계 설정 쿼리
         # for child_id in fields.get("child_stories", []):

--- a/neo_db/apps.py
+++ b/neo_db/apps.py
@@ -4,7 +4,8 @@ from django.apps import AppConfig
 from neo4j import GraphDatabase
 
 from backend import mysettings
-
+import logging
+logger = logging.getLogger(__name__)
 
 class NeoDbConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
@@ -91,6 +92,22 @@ class NeoDbConfig(AppConfig):
         CREATE (u:User {user_id: $user_id, nickname: $nickname, created_at: $created_at, updated_at: $updated_at, is_deleted: $is_deleted})
         """
         session.run(query, parameters=fields)
+
+    # @staticmethod
+    # def get_story_id(session, image_url):
+    #     # 스토리 아이디 반환 쿼리
+    #     query = """
+    #             MATCH (s:Story)
+    #             WHERE s.image_url = $image_url
+    #             RETURN ID(s) AS story_id
+    #             """
+    #     result = session.run(query, image_url=image_url)
+    #     logger.error('result: ', result)
+    #     story_id = result.single()[0]
+    #     if story_id is None:
+    #         logger.error('story_id 내용물이 없음')
+    #     logger.error('story_id: ', story_id)
+    #     return story_id
 
     @staticmethod
     def create_story(session, fields):

--- a/story/serializers.py
+++ b/story/serializers.py
@@ -31,11 +31,12 @@ class StoryCreateSerializer(serializers.ModelSerializer): # 스토리 생성 시
 
 
 class ExtendedStorySerializer(serializers.ModelSerializer): # 생성 후 response, 전체 시나리오 조회 시 사용
-    # story_id = serializers.IntegerField(source='story_id', read_only=True)  # neo4j의 story_id
+    story_id = serializers.IntegerField(read_only=True) # Neo4j의 story_id
     user_id = serializers.IntegerField(source='user.id')
     user_nickname = serializers.CharField(source='user.nickname', read_only=True)
     class Meta:
         model = Story
-        fields = ['id', 'user_id', 'user_nickname', 'content', 'image_url']
-        # fields = ['story_id', 'user_id', 'user_nickname', 'content', 'image_url']
+        fields = ['story_id', 'user_id', 'user_nickname', 'content', 'image_url']
+
+
 

--- a/story/serializers.py
+++ b/story/serializers.py
@@ -31,9 +31,11 @@ class StoryCreateSerializer(serializers.ModelSerializer): # 스토리 생성 시
 
 
 class ExtendedStorySerializer(serializers.ModelSerializer): # 생성 후 response, 전체 시나리오 조회 시 사용
+    # story_id = serializers.IntegerField(source='story_id', read_only=True)  # neo4j의 story_id
     user_id = serializers.IntegerField(source='user.id')
     user_nickname = serializers.CharField(source='user.nickname', read_only=True)
     class Meta:
         model = Story
         fields = ['id', 'user_id', 'user_nickname', 'content', 'image_url']
+        # fields = ['story_id', 'user_id', 'user_nickname', 'content', 'image_url']
 

--- a/story/views.py
+++ b/story/views.py
@@ -29,15 +29,15 @@ openai.api_key = os.getenv("GPT_API_KEY")
 
 @swagger_auto_schema(
     method='get',
-    operation_id='시나리오 전체 조회',
-    operation_description='전체 시나리오를 조회합니다.',
+    operation_id='모든 루트 스토리 조회',
+    operation_description='모든 루트 스토리를 조회합니다.',
     tags=['Story'],
 )
 
 @swagger_auto_schema(
     method='post',
     operation_id='스토리 생성',
-    operation_description='내용을 작성하여 스토리를 생성합니다.',
+    operation_description='내용을 작성하여 스토리를 생성합니다.\n\n루트 스토리인 경우, parent_story를 음수로 설정해야합니다. 분기 스토리일 경우에는 분기를 만들 스토리의 아이디가 들어가야합니다.\n\nresponse_body의 id는 스토리의 아이디를 의미합니다.',
     tags=['Story'],
     request_body=StoryCreateSerializer,
 )
@@ -114,7 +114,7 @@ def story_list_create(request, *args, **kwargs):
 @swagger_auto_schema(
     method='post',
     operation_id='이미지 생성 요청',
-    operation_description='내용에 맞게 ai 이미지를 생성 요청합니다.',
+    operation_description='내용에 맞게 ai 이미지를 생성합니다.\n\n반환되는 URL은 임시이며, 버킷에 저장되는 URL은 스토리 생성 이후 생성됩니다.',
     tags=['Story'],
     request_body=openapi.Schema(
         type=openapi.TYPE_OBJECT,
@@ -215,7 +215,7 @@ def story_detail(request, story_id):
 @swagger_auto_schema(
     method='get',
     operation_id='전체 스토리 조회',
-    operation_description='전체 스토리를 조회합니다.',
+    operation_description='전체 스토리를 조회합니다.\n\n스토리는 깊이 탐색 순서로 나열 됩니다.',
     tags=['Story'],
 )
 


### PR DESCRIPTION
## Summary
*한 줄 설명*
스토리 조회 및 생성 시 neo4j 스토리 아이디 response 구현

## Description
- *어떤 코드가 추가/변경 됐는지*
- neodb/apps.py에서 image_url을 통해 id 받아오는 함수 구현
- story/serializers.py에서 ExtendedStorySerializer에 story_id 추가
- story/views.py에서 neo4j 아이디 받아와서 response에 추가

## Screenshots
*실행 결과 스크린샷*
- 전체 조회 시

<img width="849" alt="스크린샷 2024-01-16 오후 7 46 51" src="https://github.com/2023-Winter-Bootcamp-Team-J/backend/assets/94193594/b20e907a-d707-4cc6-bb1b-e19edeccb415">

- 루트 스토리 생성 시

<img width="851" alt="스크린샷 2024-01-16 오후 7 24 04" src="https://github.com/2023-Winter-Bootcamp-Team-J/backend/assets/94193594/09c4def1-cecb-4a49-a348-037ee6dabce9">

- 분기 스토리 생성 시

<img width="848" alt="스크린샷 2024-01-16 오후 7 46 05" src="https://github.com/2023-Winter-Bootcamp-Team-J/backend/assets/94193594/64f43f8b-8611-4d45-a4cc-7e940368c982">

## Test Checklist
- [ ] *테스트할 사람이 어떤 것을 확인하면 좋을지*
- [ ] 
